### PR TITLE
Retry failed connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 13.3.0
+* Added retry failed connection for requests
+* Fixed minor Rubocop error in configuration
+
 ## 12.0.0
 ### Added
 * NoTask - Added ditto endpoint

--- a/bwapi.gemspec
+++ b/bwapi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email       = 'automation@brandwatch.com'
   s.license     = 'MIT'
   s.homepage    = 'https://github.com/BrandwatchLtd/bwapi'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/bwapi/configuration.rb
+++ b/lib/bwapi/configuration.rb
@@ -10,25 +10,25 @@ module BWAPI
     class << self
       # Configuration keys
       def keys
-        @keys ||= [
-          :access_token,
-          :access_token_expiry,
-          :adapter,
-          :api_endpoint,
-          :client_id,
-          :client_secret,
-          :connection_options,
-          :debug,
-          :grant_type,
-          :logger,
-          :open_timeout,
-          :password,
-          :performance,
-          :refresh_token,
-          :timeout,
-          :user_agent,
-          :username,
-          :verify_ssl
+        @keys ||= %i[
+          access_token
+          access_token_expiry
+          adapter
+          api_endpoint
+          client_id
+          client_secret
+          connection_options
+          debug
+          grant_type
+          logger
+          open_timeout
+          password
+          performance
+          refresh_token
+          timeout
+          user_agent
+          username
+          verify_ssl
         ]
       end
     end

--- a/lib/bwapi/configuration.rb
+++ b/lib/bwapi/configuration.rb
@@ -3,7 +3,7 @@ module BWAPI
   module Configuration
     attr_accessor :access_token, :access_token_expiry, :adapter, :api_endpoint, :client_id, :debug,
                   :grant_type, :logger, :open_timeout, :performance, :refresh_token, :timeout,
-                  :user_agent, :username, :verify_ssl
+                  :user_agent, :username, :verify_ssl, :connection_attempts
 
     attr_writer :client_secret, :password
 
@@ -18,6 +18,7 @@ module BWAPI
           client_id
           client_secret
           connection_options
+          connection_attempts
           debug
           grant_type
           logger

--- a/lib/bwapi/default.rb
+++ b/lib/bwapi/default.rb
@@ -57,6 +57,10 @@ module BWAPI
         }
       end
 
+      def connection_attempts
+        ENV['BWAPI_CONNECTION_ATTEMPTS'] ? ENV['BWAPI_CONNECTION_ATTEMPTS'].to_i : 1
+      end
+
       def debug
         ENV['BWAPI_DEBUG'] == 'true' ? true : false
       end

--- a/lib/bwapi/request.rb
+++ b/lib/bwapi/request.rb
@@ -57,12 +57,12 @@ module BWAPI
     # @param opts [Hash] Request parameters
     # @return [Hash] Response
     def request(method, path, opts = {})
-      retries ||= 0
+      tries ||= 0
       send_request(method, path, opts)
     rescue Faraday::ConnectionFailed => e
       warn "Faraday failed to connect with the error: #{e.message}"
-      raise e unless (retries += 1) < 3
-      warn "Reseting and retrying. Retry: #{retries}"
+      raise e unless (tries += 1) < connection_attempts
+      warn "Resetting and retrying. Retry: #{tries}"
       reset_connection
       retry
     end

--- a/lib/bwapi/request.rb
+++ b/lib/bwapi/request.rb
@@ -57,6 +57,23 @@ module BWAPI
     # @param opts [Hash] Request parameters
     # @return [Hash] Response
     def request(method, path, opts = {})
+      retries ||= 0
+      send_request(method, path, opts)
+    rescue Faraday::ConnectionFailed => e
+      warn "Faraday failed to connect with the error: #{e.message}"
+      raise e unless (retries += 1) < 3
+      warn "Reseting and retrying. Retry: #{retries}"
+      reset_connection
+      retry
+    end
+
+    # Send the request to the connection object
+    #
+    # @param method [String] Type of request
+    # @param path [String] URL path to send request
+    # @param opts [Hash] Request parameters
+    # @return [Hash] Response
+    def send_request(method, path, opts)
       connection.send(method) do |req|
         case method
         when :get

--- a/lib/bwapi/version.rb
+++ b/lib/bwapi/version.rb
@@ -1,4 +1,4 @@
 # BWAPI Version
 module BWAPI
-  VERSION = '13.2.0'.freeze
+  VERSION = '13.3.0'.freeze
 end

--- a/spec/bwapi/configuration_spec.rb
+++ b/spec/bwapi/configuration_spec.rb
@@ -408,7 +408,7 @@ describe BWAPI::Configuration do
     end
 
     it 'should reset the user_agent value' do
-      expect(bwapi.user_agent).to eql('BWAPI Ruby Gem 13.2.0')
+      expect(bwapi.user_agent).to eql('BWAPI Ruby Gem 13.3.0')
     end
 
     it 'should reset the username value' do
@@ -509,7 +509,7 @@ describe BWAPI::Configuration do
         client_secret: nil,
         connection_options: {
           headers: {
-            user_agent: 'BWAPI Ruby Gem 13.2.0'
+            user_agent: 'BWAPI Ruby Gem 13.3.0'
           },
           request: {
             params_encoder: Faraday::FlatParamsEncoder
@@ -524,7 +524,7 @@ describe BWAPI::Configuration do
         performance: {},
         refresh_token: nil,
         timeout: 60,
-        user_agent: 'BWAPI Ruby Gem 13.2.0',
+        user_agent: 'BWAPI Ruby Gem 13.3.0',
         username: nil,
         verify_ssl: false
       )

--- a/spec/bwapi/configuration_spec.rb
+++ b/spec/bwapi/configuration_spec.rb
@@ -238,6 +238,7 @@ describe BWAPI::Configuration do
           :client_id,
           :client_secret,
           :connection_options,
+          :connection_attempts,
           :debug,
           :grant_type,
           :logger,
@@ -514,6 +515,7 @@ describe BWAPI::Configuration do
             params_encoder: Faraday::FlatParamsEncoder
           }
         },
+        connection_attempts: 1,
         debug: false,
         grant_type: 'api-password',
         logger: nil,

--- a/spec/bwapi/default_spec.rb
+++ b/spec/bwapi/default_spec.rb
@@ -34,7 +34,7 @@ describe BWAPI::Default do
         client_secret: nil,
         connection_options: {
           headers: {
-            user_agent: 'BWAPI Ruby Gem 13.2.0'
+            user_agent: 'BWAPI Ruby Gem 13.3.0'
           },
           request: {
             params_encoder: Faraday::FlatParamsEncoder
@@ -49,7 +49,7 @@ describe BWAPI::Default do
         performance: {},
         refresh_token: nil,
         timeout: 60,
-        user_agent: 'BWAPI Ruby Gem 13.2.0',
+        user_agent: 'BWAPI Ruby Gem 13.3.0',
         username: nil,
         verify_ssl: false
       )
@@ -131,7 +131,7 @@ describe BWAPI::Default do
     it 'should return the default hash values' do
       expect(BWAPI::Default.connection_options).to eql(
         headers: {
-          user_agent: 'BWAPI Ruby Gem 13.2.0'
+          user_agent: 'BWAPI Ruby Gem 13.3.0'
         },
         request: {
           params_encoder: Faraday::FlatParamsEncoder

--- a/spec/bwapi/default_spec.rb
+++ b/spec/bwapi/default_spec.rb
@@ -40,6 +40,7 @@ describe BWAPI::Default do
             params_encoder: Faraday::FlatParamsEncoder
           }
         },
+        connection_attempts: 1,
         debug: false,
         grant_type: 'api-password',
         logger: nil,
@@ -136,6 +137,19 @@ describe BWAPI::Default do
           params_encoder: Faraday::FlatParamsEncoder
         }
       )
+    end
+  end
+
+  describe '.connection_attempts' do
+    after { ENV['BWAPI_CONNECTION_ATTEMPTS'] = nil }
+
+    it 'should return 1 as default' do
+      expect(BWAPI::Default.connection_attempts).to eql(1)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_CONNECTION_ATTEMPTS'] = '3'
+      expect(BWAPI::Default.connection_attempts).to eql(3)
     end
   end
 

--- a/spec/bwapi/request_spec.rb
+++ b/spec/bwapi/request_spec.rb
@@ -1,0 +1,79 @@
+require 'helper'
+
+describe BWAPI::Request do
+  let(:connection) { double(:connection) }
+  let(:request) { double(:request) }
+  let(:response) { double(:response) }
+
+  before do
+    allow_any_instance_of(BWAPI::Connection).to receive(:connection).and_return(connection)
+    allow(response).to receive(:body)
+  end
+
+  subject { BWAPI.new }
+
+  describe '#get' do
+    before do
+      allow(connection).to receive(:get).and_yield(request).and_return(response)
+    end
+
+    it 'should make a get request' do
+      expect(request).to receive(:url).with('/ping', {})
+      subject.get('/ping')
+    end
+
+    it 'should retry on a failed connection' do
+      expect(connection).to receive(:get).and_yield(request).and_raise(Faraday::ConnectionFailed, 'error').once
+      expect(connection).to receive(:get).and_yield(request).and_return(response).once
+      expect(request).to receive(:url).with('/ping', {}).twice
+      expect { subject.get('/ping') }.to output("Faraday failed to connect with the error: error\nReseting and retrying. Retry: 1\n").to_stderr
+    end
+  end
+
+  describe '#delete' do
+    before do
+      allow(connection).to receive(:delete).and_yield(request).and_return(response)
+    end
+
+    it 'should make a delete request' do
+      expect(request).to receive(:url).with('/ping', {})
+      subject.delete('/ping')
+    end
+  end
+
+  describe '#post' do
+    before do
+      allow(connection).to receive(:post).and_yield(request).and_return(response)
+    end
+
+    it 'should make a post request' do
+      expect(request).to receive(:path=).with('/ping')
+      expect(request).to receive(:body=).with({})
+      subject.post('/ping')
+    end
+  end
+
+  describe '#put' do
+    before do
+      allow(connection).to receive(:put).and_yield(request).and_return(response)
+    end
+
+    it 'should make a put request' do
+      expect(request).to receive(:path=).with('/ping')
+      expect(request).to receive(:body=).with({})
+      subject.put('/ping')
+    end
+  end
+
+  describe '#patch' do
+    before do
+      allow(connection).to receive(:patch).and_yield(request).and_return(response)
+    end
+
+    it 'should make a patch request' do
+      expect(request).to receive(:path=).with('/ping')
+      expect(request).to receive(:body=).with({})
+      subject.patch('/ping')
+    end
+  end
+end

--- a/spec/bwapi/request_spec.rb
+++ b/spec/bwapi/request_spec.rb
@@ -22,11 +22,29 @@ describe BWAPI::Request do
       subject.get('/ping')
     end
 
-    it 'should retry on a failed connection' do
-      expect(connection).to receive(:get).and_yield(request).and_raise(Faraday::ConnectionFailed, 'error').once
-      expect(connection).to receive(:get).and_yield(request).and_return(response).once
-      expect(request).to receive(:url).with('/ping', {}).twice
-      expect { subject.get('/ping') }.to output("Faraday failed to connect with the error: error\nReseting and retrying. Retry: 1\n").to_stderr
+    context 'with a connection error' do
+      it 'should raise the error when tries not configured' do
+        expect(connection).to receive(:get).and_yield(request).and_raise(Faraday::ConnectionFailed, 'error').once
+        expect(request).to receive(:url).with('/ping', {}).once
+        expect { subject.get('/ping') }.to raise_exception(Faraday::ConnectionFailed, 'error').and output("Faraday failed to connect with the error: error\n").to_stderr
+      end
+
+      it 'should not raise the error when tries configured' do
+        expect(connection).to receive(:get).and_yield(request).and_raise(Faraday::ConnectionFailed, 'error').once
+        expect(connection).to receive(:get).and_yield(request).and_return(response).once
+        expect(request).to receive(:url).with('/ping', {}).twice
+
+        subject.connection_attempts = 2
+        expect { subject.get('/ping') }.to output("Faraday failed to connect with the error: error\nResetting and retrying. Retry: 1\n").to_stderr
+      end
+
+      it 'should raise the error when tries exceed' do
+        expect(connection).to receive(:get).and_yield(request).and_raise(Faraday::ConnectionFailed, 'error').exactly(3).times
+        expect(request).to receive(:url).with('/ping', {}).exactly(3).times
+
+        subject.connection_attempts = 3
+        expect { subject.get('/ping') }.to raise_exception(Faraday::ConnectionFailed, 'error').and output.to_stderr
+      end
     end
   end
 


### PR DESCRIPTION
* Added retry failed connection for requests  
    When a request gets a failed connection error then the request will be retried.
    This is to catch the Faraday::ConnectionFailed that has been seen recently.
    I have included warnings so as to try to ensure that it does not go unnoticed.
* Added connection attempts for connection retries
    The user can now configure the number of connection attempts.
    The default has been set to 1 connection attempt.
    This will be no retries.
    A retry will happen if the tries is lower than the configured connection_attempts
* Fixed minor Rubocop error in configuration